### PR TITLE
Missing VkStridedBufferRegionKHR.stride?

### DIFF
--- a/samples/extensions/raytracing_basic/raytracing_basic.cpp
+++ b/samples/extensions/raytracing_basic/raytracing_basic.cpp
@@ -599,16 +599,19 @@ void RaytracingBasic::build_command_buffers()
 		VkStridedBufferRegionKHR raygen_shader_sbt_entry{};
 		raygen_shader_sbt_entry.buffer = shader_binding_table->get_handle();
 		raygen_shader_sbt_entry.offset = static_cast<VkDeviceSize>(ray_tracing_properties.shaderGroupHandleSize * INDEX_RAYGEN);
+		raygen_shader_sbt_entry.stride = ray_tracing_properties.shaderGroupHandleSize;
 		raygen_shader_sbt_entry.size   = ray_tracing_properties.shaderGroupHandleSize;
 
 		VkStridedBufferRegionKHR miss_shader_sbt_entry{};
 		miss_shader_sbt_entry.buffer = shader_binding_table->get_handle();
 		miss_shader_sbt_entry.offset = static_cast<VkDeviceSize>(ray_tracing_properties.shaderGroupHandleSize * INDEX_MISS);
+		miss_shader_sbt_entry.stride = ray_tracing_properties.shaderGroupHandleSize;
 		miss_shader_sbt_entry.size   = ray_tracing_properties.shaderGroupHandleSize;
 
 		VkStridedBufferRegionKHR hit_shader_sbt_entry{};
 		hit_shader_sbt_entry.buffer = shader_binding_table->get_handle();
 		hit_shader_sbt_entry.offset = static_cast<VkDeviceSize>(ray_tracing_properties.shaderGroupHandleSize * INDEX_CLOSEST_HIT);
+		hit_shader_sbt_entry.stride = ray_tracing_properties.shaderGroupHandleSize;
 		hit_shader_sbt_entry.size   = ray_tracing_properties.shaderGroupHandleSize;
 
 		VkStridedBufferRegionKHR callable_shader_sbt_entry{};


### PR DESCRIPTION
Probably not a problem here, but it does cause some problem when I try to copy the pattern into my project.

## Description

Please include a summary of the change, new sample or fixed issue. Please also include relevant motivation and context.
Please read the [contribution guidelines](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md)

Fixes #<issue number>

## General Checklist:

Please ensure the following points are checked:

- [X ] My code follows the [coding style](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Code-Style)
- [ X] I have reviewed file [licenses](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#Copyright-Notice-and-License-Template)
- [ X] I have commented any added functions (in line with Doxygen)
- [ X] I have commented any code that could be hard to understand
- [X ] My changes do not add any new compiler warnings
- [X ] My changes do not add any new validation layer errors or warnings
- [X ] I have used existing framework/helper functions where possible
- [X ] My changes build and run on Windows, Linux, macOS and Android. Otherwise I have [documented any exceptions](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)

## Sample Checklist

If your PR contains a new or modified sample, these further checks must be carried out *in addition* to the General Checklist:
- [X ] I have tested the sample on at least one compliant Vulkan implementation
- [ X] If the sample is vendor-specific, I have [tagged it appropriately](https://github.com/KhronosGroup/Vulkan-Samples/tree/master/CONTRIBUTING.md#General-Requirements)
- [ X] I have stated on what implementation the sample has been tested so that others can test on different implementations and platforms
- [ X] Any dependent assets have been merged and published in downstream modules